### PR TITLE
Ontology neo4j

### DIFF
--- a/bluegraph/core/io.py
+++ b/bluegraph/core/io.py
@@ -1238,8 +1238,11 @@ class PandasPGFrame(PGFrame):
                 targets[s].add(o)
             elif p not in predicates_to_ignore:
                 # Extract other props as is
-                prop_name = str(p)
-                props[prop_name][label_mapping[s]] = str(o)
+                if p in label_mapping:
+                    props[label_mapping[p]][label_mapping[s]] = str(o)
+                else:
+                    prop_name = str(p)
+                    props[prop_name][label_mapping[s]] = str(o)
 
         # Combine sources and targets to extract relationships
         for k, v in sources.items():

--- a/tests/io/test_pgframes.py
+++ b/tests/io/test_pgframes.py
@@ -183,12 +183,14 @@ def test_neo4j_io(random_pgframe, neo4j_driver):
     view._clear()
     pgframe_to_neo4j(
         random_pgframe, driver=neo4j_driver,
+        node_label="TestIONode",
         node_types_as_labels=True,
         edge_types_as_labels=True)
 
     view._clear()
     pgframe_to_neo4j(
         random_pgframe, driver=neo4j_driver,
+        node_label="TestIONode",
         node_types_as_labels=True,
         edge_types_as_labels=True)
 
@@ -196,8 +198,16 @@ def test_neo4j_io(random_pgframe, neo4j_driver):
 def test_from_ontology():
     frame = PandasPGFrame.from_ontology(
         "tests/test_ontology.ttl")
-    print(frame)
-
+    assert(frame.number_of_nodes() == 10)
+    assert(frame.number_of_edges() == 14)
+    assert(
+        frame.get_node_property_values("a").loc["Agent"] == "hello")
+    assert(
+        frame.get_node_property_values("a").loc["Action"] == "Lala")
+    assert(
+        frame.get_node_property_values("b").loc["Agent"] == "bye")
+    assert(
+        frame.get_node_property_values("b").loc["Action"] == "Lblb")
 
 def test_stellargraph_io(random_pgframe):
     sg_object = pgframe_to_stellargraph(random_pgframe)

--- a/tests/test_ontology.ttl
+++ b/tests/test_ontology.ttl
@@ -1,0 +1,146 @@
+@prefix : <http://webprotege.stanford.edu/project/906hvpTv7VrF1N7GxOKP8a#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@base <http://webprotege.stanford.edu/project/906hvpTv7VrF1N7GxOKP8a> .
+
+<http://webprotege.stanford.edu/project/906hvpTv7VrF1N7GxOKP8a> rdf:type owl:Ontology .
+
+#################################################################
+#    Annotation properties
+#################################################################
+
+###  http://webprotege.stanford.edu/R7kGimIWyQsFeKP03Jp7BBY
+<http://webprotege.stanford.edu/R7kGimIWyQsFeKP03Jp7BBY> rdf:type owl:AnnotationProperty ;
+                                                         rdfs:label "b"@en .
+
+
+###  http://webprotege.stanford.edu/RCjUgC0IBElvukbHuHnbDKH
+<http://webprotege.stanford.edu/RCjUgC0IBElvukbHuHnbDKH> rdf:type owl:AnnotationProperty ;
+                                                         rdfs:label "a"@en .
+
+
+#################################################################
+#    Object Properties
+#################################################################
+
+###  http://webprotege.stanford.edu/R7ae7fg6EugVkXM1TjlQgYm
+<http://webprotege.stanford.edu/R7ae7fg6EugVkXM1TjlQgYm> rdf:type owl:ObjectProperty ;
+                                                         rdfs:label "contribution"@en .
+
+
+###  http://webprotege.stanford.edu/R9vzrpfOUlTHlf1DeEI6882
+<http://webprotege.stanford.edu/R9vzrpfOUlTHlf1DeEI6882> rdf:type owl:ObjectProperty ;
+                                                         rdfs:label "describes"@en .
+
+
+###  http://webprotege.stanford.edu/RBsRcGpSA8DFfScADRa5bXN
+<http://webprotege.stanford.edu/RBsRcGpSA8DFfScADRa5bXN> rdf:type owl:ObjectProperty ;
+                                                         rdfs:label "generated"@en .
+
+
+###  http://webprotege.stanford.edu/RCBDjcvdwtuj3lS81jAmPoX
+<http://webprotege.stanford.edu/RCBDjcvdwtuj3lS81jAmPoX> rdf:type owl:ObjectProperty ;
+                                                         rdfs:label "used"@en .
+
+
+#################################################################
+#    Classes
+#################################################################
+
+###  http://webprotege.stanford.edu/R37TdREoWTRYczlOjL0OM3
+<http://webprotege.stanford.edu/R37TdREoWTRYczlOjL0OM3> rdf:type owl:Class ;
+                                                        rdfs:subClassOf <http://webprotege.stanford.edu/R9HPX2vAdqKXR44NJktgfd> ,
+                                                                        [ rdf:type owl:Restriction ;
+                                                                          owl:onProperty <http://webprotege.stanford.edu/R9vzrpfOUlTHlf1DeEI6882> ;
+                                                                          owl:someValuesFrom <http://webprotege.stanford.edu/R9t8ZujxPizGemEuYFI00do>
+                                                                        ] ;
+                                                        rdfs:label "Model"@en .
+
+
+###  http://webprotege.stanford.edu/R74cQvjSGP81aHTC5H29A6n
+<http://webprotege.stanford.edu/R74cQvjSGP81aHTC5H29A6n> rdf:type owl:Class ;
+                                                         rdfs:subClassOf <http://webprotege.stanford.edu/R9HPX2vAdqKXR44NJktgfd> ;
+                                                         rdfs:label "Data"@en .
+
+
+###  http://webprotege.stanford.edu/R7rj4zHsNmDU6iEazJ9nUJs
+<http://webprotege.stanford.edu/R7rj4zHsNmDU6iEazJ9nUJs> rdf:type owl:Class ;
+                                                         rdfs:subClassOf <http://webprotege.stanford.edu/RCygwSofQzTHNSREch4rX0H> ,
+                                                                         [ rdf:type owl:Restriction ;
+                                                                           owl:onProperty <http://webprotege.stanford.edu/RBsRcGpSA8DFfScADRa5bXN> ;
+                                                                           owl:someValuesFrom <http://webprotege.stanford.edu/R74cQvjSGP81aHTC5H29A6n>
+                                                                         ] ,
+                                                                         [ rdf:type owl:Restriction ;
+                                                                           owl:onProperty <http://webprotege.stanford.edu/RCBDjcvdwtuj3lS81jAmPoX> ;
+                                                                           owl:someValuesFrom <http://webprotege.stanford.edu/R9t8ZujxPizGemEuYFI00do>
+                                                                         ] ;
+                                                         rdfs:label "Experiment"@en .
+
+
+###  http://webprotege.stanford.edu/R88dDsthRSGxyEwvgpEy7GE
+<http://webprotege.stanford.edu/R88dDsthRSGxyEwvgpEy7GE> rdf:type owl:Class ;
+                                                         rdfs:subClassOf <http://webprotege.stanford.edu/RDgjAkuqf5lwWMaSGxlXFnr> ;
+                                                         rdfs:label "Software"@en .
+
+
+###  http://webprotege.stanford.edu/R8LvBzl4pVw0h6ZuWz19bwa
+<http://webprotege.stanford.edu/R8LvBzl4pVw0h6ZuWz19bwa> rdf:type owl:Class ;
+                                                         rdfs:subClassOf <http://webprotege.stanford.edu/RCygwSofQzTHNSREch4rX0H> ,
+                                                                         [ rdf:type owl:Restriction ;
+                                                                           owl:onProperty <http://webprotege.stanford.edu/RBsRcGpSA8DFfScADRa5bXN> ;
+                                                                           owl:someValuesFrom <http://webprotege.stanford.edu/R37TdREoWTRYczlOjL0OM3>
+                                                                         ] ,
+                                                                         [ rdf:type owl:Restriction ;
+                                                                           owl:onProperty <http://webprotege.stanford.edu/RCBDjcvdwtuj3lS81jAmPoX> ;
+                                                                           owl:someValuesFrom <http://webprotege.stanford.edu/R74cQvjSGP81aHTC5H29A6n>
+                                                                         ] ;
+                                                         rdfs:label "Modelling"@en .
+
+
+###  http://webprotege.stanford.edu/R9HPX2vAdqKXR44NJktgfd
+<http://webprotege.stanford.edu/R9HPX2vAdqKXR44NJktgfd> rdf:type owl:Class ;
+                                                        rdfs:label "Entity"@en .
+
+
+###  http://webprotege.stanford.edu/R9t8ZujxPizGemEuYFI00do
+<http://webprotege.stanford.edu/R9t8ZujxPizGemEuYFI00do> rdf:type owl:Class ;
+                                                         rdfs:subClassOf <http://webprotege.stanford.edu/R9HPX2vAdqKXR44NJktgfd> ;
+                                                         rdfs:label "BiologicalEntity"@en .
+
+
+###  http://webprotege.stanford.edu/RCygwSofQzTHNSREch4rX0H
+<http://webprotege.stanford.edu/RCygwSofQzTHNSREch4rX0H> rdf:type owl:Class ;
+                                                         rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                                                           owl:onProperty <http://webprotege.stanford.edu/R7ae7fg6EugVkXM1TjlQgYm> ;
+                                                                           owl:someValuesFrom <http://webprotege.stanford.edu/RDgjAkuqf5lwWMaSGxlXFnr>
+                                                                         ] ,
+                                                                         [ rdf:type owl:Restriction ;
+                                                                           owl:onProperty <http://webprotege.stanford.edu/RBsRcGpSA8DFfScADRa5bXN> ;
+                                                                           owl:someValuesFrom <http://webprotege.stanford.edu/R9HPX2vAdqKXR44NJktgfd>
+                                                                         ] ,
+                                                                         [ rdf:type owl:Restriction ;
+                                                                           owl:onProperty <http://webprotege.stanford.edu/RCBDjcvdwtuj3lS81jAmPoX> ;
+                                                                           owl:someValuesFrom <http://webprotege.stanford.edu/R9HPX2vAdqKXR44NJktgfd>
+                                                                         ] ;
+                                                         <http://webprotege.stanford.edu/R7kGimIWyQsFeKP03Jp7BBY> "\"Lblb\""^^xsd:string ;
+                                                         <http://webprotege.stanford.edu/RCjUgC0IBElvukbHuHnbDKH> "\"Lala\""^^xsd:string ;
+                                                         rdfs:label "Action"@en .
+
+
+###  http://webprotege.stanford.edu/RDR7xgEuPQoo1bfj29P0viJ
+<http://webprotege.stanford.edu/RDR7xgEuPQoo1bfj29P0viJ> rdf:type owl:Class ;
+                                                         rdfs:subClassOf <http://webprotege.stanford.edu/RDgjAkuqf5lwWMaSGxlXFnr> ;
+                                                         rdfs:label "Person"@en .
+
+
+###  http://webprotege.stanford.edu/RDgjAkuqf5lwWMaSGxlXFnr
+<http://webprotege.stanford.edu/RDgjAkuqf5lwWMaSGxlXFnr> rdf:type owl:Class ;
+                                                         <http://webprotege.stanford.edu/R7kGimIWyQsFeKP03Jp7BBY> "bye"^^xsd:string ;
+                                                         <http://webprotege.stanford.edu/RCjUgC0IBElvukbHuHnbDKH> "hello"^^xsd:string ;
+                                                         rdfs:label "Agent"@en .
+
+
+###  Generated by the OWL API (version 4.5.10) https://github.com/owlcs/owlapi

--- a/tests/test_ontology.ttl
+++ b/tests/test_ontology.ttl
@@ -125,8 +125,8 @@
                                                                            owl:onProperty <http://webprotege.stanford.edu/RCBDjcvdwtuj3lS81jAmPoX> ;
                                                                            owl:someValuesFrom <http://webprotege.stanford.edu/R9HPX2vAdqKXR44NJktgfd>
                                                                          ] ;
-                                                         <http://webprotege.stanford.edu/R7kGimIWyQsFeKP03Jp7BBY> "\"Lblb\""^^xsd:string ;
-                                                         <http://webprotege.stanford.edu/RCjUgC0IBElvukbHuHnbDKH> "\"Lala\""^^xsd:string ;
+                                                         <http://webprotege.stanford.edu/R7kGimIWyQsFeKP03Jp7BBY> "Lblb"^^xsd:string ;
+                                                         <http://webprotege.stanford.edu/RCjUgC0IBElvukbHuHnbDKH> "Lala"^^xsd:string ;
                                                          rdfs:label "Action"@en .
 
 


### PR DESCRIPTION
Updates to `PGFrame`:

- added `rename_node_properties` and `rename_edge_properties`
- added docstrings
- added `from_ontology` classmethod for importing (e.g. Webprotege) ontologies as property graphs

Fixes to `pgframe_to_neo4j`:

- Edges with multiple types result in multiple Neo4j relations with respective types

Added more tests